### PR TITLE
Support ':' in @Path segments

### DIFF
--- a/processor/src/main/java/com/tickaroo/tikxml/processor/field/PathDetector.kt
+++ b/processor/src/main/java/com/tickaroo/tikxml/processor/field/PathDetector.kt
@@ -37,7 +37,7 @@ import kotlin.text.split
 object PathDetector {
 
     private val PATH_SEGMENT_DIVIDER = '/'
-    private val SEGMENT_REGEX = Regex("\\w+")
+    private val SEGMENT_REGEX = Regex("[\\w:]+")
 
 
     fun extractPathSegments(element: VariableElement, pathAsString: String): List<String> {

--- a/processor/src/test/java/com/tickaroo/tikxml/processor/field/PathDetectorTest.kt
+++ b/processor/src/test/java/com/tickaroo/tikxml/processor/field/PathDetectorTest.kt
@@ -99,6 +99,12 @@ class PathDetectorTest {
         assertEquals("asd", segments[2])
     }
 
+    @Test fun namespacedPath() {
+        val segments = PathDetector.extractPathSegments(element, "foo:bar")
+        assertEquals(1, segments.size)
+        assertEquals("foo:bar", segments[0])
+    }
+
     @Test fun tripplePathTrailingSlash() {
         expectException {
             PathDetector.extractPathSegments(element, "foo/bar/asd/")


### PR DESCRIPTION
Right now there is no xml namespace support, but you can declare fully
qualified names to match elements. However, this is disallowed in the
`@Path` annotation making matching on them impossible.

For example, you cannot match
```xml
<foo>
  <media:content>
    <item>Item1<item/>
    <item>Item2<item/>
  </media:content>
</foo>
```
to
```java
@Xml
public class Foo {
  @Path(?)
  @Element
  public List<Item> items;
}

@Xml
public class Item {
  @TextContent
  public String value;
}
```

because `@Path("content")` will fail to match `<media:content>` and `@Path("media:content")` fails to compile.

Ideally, full namespace support should be implemented, but this is a simple solution that works great in the case the namespace qualifiers are stable.