### PR TITLE
Use qualifiedName for generated TypeAdapter package

### DIFF
--- a/processor/src/main/java/com/tickaroo/tikxml/processor/generator/TypeAdapterCodeGenerator.kt
+++ b/processor/src/main/java/com/tickaroo/tikxml/processor/generator/TypeAdapterCodeGenerator.kt
@@ -95,7 +95,7 @@ class TypeAdapterCodeGenerator(private val filer: Filer, private val elementUtil
 
 
         val packageElement = elementUtils.getPackageOf(annotatedClass.element)
-        val packageName = if (packageElement.isUnnamed) "" else packageElement.toString()
+        val packageName = if (packageElement.isUnnamed) "" else packageElement.qualifiedName.toString()
 
         val javaFile = JavaFile.builder(packageName, adapterClassBuilder.build()).build()
         javaFile.writeTo(filer)


### PR DESCRIPTION
`PackageElement#toString()` is undefined by the language documentation, so it appears different compilers have different output. For example, ECJ and JACK return:

`package <package name>`

While javac returns:

`<package name>`

This can result in a duplicate `package` token in generated TypeAdapters.

This change explicitly asks for the package element's `qualifiedName`, which is really what we want.
