### PR TITLE
Default constructor fix 

### DIFF
--- a/processor-common/src/main/java/com/tickaroo/tikxml/processor/utils/ElementExtensions.kt
+++ b/processor-common/src/main/java/com/tickaroo/tikxml/processor/utils/ElementExtensions.kt
@@ -101,10 +101,15 @@ fun Element.isMethod() = kind == ElementKind.METHOD
 fun Element.isConstructor() = kind == ElementKind.CONSTRUCTOR
 
 /**
+ * Checks if a given element has parameters
+ */
+fun Element.hasEmptyParameters()  =  (this as ExecutableElement).parameters.isEmpty()
+
+/**
  * Checks if a given element is an Empty constructor (visibility not checked)
  */
 fun Element.isEmptyConstructor() =
-        isConstructor() && (this as ExecutableElement).parameters.isEmpty()
+        isConstructor() && hasEmptyParameters()
 
 /**
  * Checks if a given element is empty constructor with minimum package visibility


### PR DESCRIPTION
I have today problem with error:
**Class X must provide an public empty (parameter-less) constructor**

when the class has valid empty constructor inherited from java.lang.Object.

Example:
```
@Xml
class AAction {
}

@Xml
class BAction {
}

@Xml(name = "event")
public class Event {
    @Path("action")
    @Element(typesByElement = {
     @ElementNameMatcher(name = "aaction", type = AAction.class),
            @ElementNameMatcher(name = "baction", type = BAction,class)
    })
    public Object action;
}
```

