### PR TITLE
Fix Exception when handling XML files encoded with UTF8-BOM

### DIFF
--- a/core/src/test/java/com/tickaroo/tikxml/XmlReaderTest.java
+++ b/core/src/test/java/com/tickaroo/tikxml/XmlReaderTest.java
@@ -18,11 +18,13 @@
 
 package com.tickaroo.tikxml;
 
-import java.io.IOException;
+import okio.Buffer;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import java.io.IOException;
 
 import static com.tickaroo.tikxml.TestUtils.readerFrom;
 
@@ -127,6 +129,28 @@ public class XmlReaderTest {
   public void validWithWhitespaces() throws IOException {
     String xml = "<  element    a = \"qwe\"  ></element>";
     XmlReader reader = readerFrom(xml);
+
+    try {
+      reader.beginElement();
+      Assert.assertEquals("element", reader.nextElementName());
+      Assert.assertEquals("a", reader.nextAttributeName());
+      Assert.assertEquals("qwe", reader.nextAttributeValue());
+      Assert.assertFalse(reader.hasTextContent());
+      reader.endElement();
+    } finally {
+      reader.close();
+    }
+  }
+
+  @Test
+  public void readXmlWithUtf8Bom() throws IOException {
+    String xml = "<element a=\"qwe\"></element>";
+    Buffer xmlWithUtf8Bom = new Buffer();
+    xmlWithUtf8Bom.writeByte(0xEF);
+    xmlWithUtf8Bom.writeByte(0xBB);
+    xmlWithUtf8Bom.writeByte(0xBF);
+    xmlWithUtf8Bom.writeUtf8(xml);
+    XmlReader reader = XmlReader.of(xmlWithUtf8Bom);
 
     try {
       reader.beginElement();


### PR DESCRIPTION
When trying to deserialize an XML file encoded as UTF-8 with Byte Order Mark (BOM) ([see also](https://stackoverflow.com/a/2223926/1502352)), tikxml crashed with `java.lang.AssertionError: Unknown XmlToken: Peeked = 0`.

This is because files with this encoding contain the magic value 0xEFBBBF as their first three bytes. Fortunately, the rest of the encoding is completely identical with UTF-8, which is why I introduced a check for this header. In case it is found, these three bytes are simply skipped.