### PR TITLE
Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ limitations under the License.
 ```
 
 
-#### Releaseing on Maven central
+#### Releasing on Maven Central
 
-If you are a Tickaroo employee and you want to release a new version on maven central, 
-take a look [at this document](https://github.com/Tickaroo/tikxml/Releasing.md)
+If you are a Tickaroo employee and you want to release a new version on Maven Central, 
+take a look [at this document](https://github.com/Tickaroo/tikxml/blob/master/Releasing.md)


### PR DESCRIPTION
Corrected typo in "Releasing on Maven central", capitalized Maven Central and corrected dead link to "Releasing" page.

Petty but was just going through the README and quick starts to learn about it and noticed the above.