### PR TITLE
Update Jacoco Plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -183,7 +183,7 @@
                 <plugin>
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
-                    <version>0.7.7.201606060606</version>
+                    <version>0.8.2</version>
                     <executions>
                         <execution>
                             <goals>


### PR DESCRIPTION
The Jacoco Plugin 0.8.2 has more Kotlin supports than 0.7.7. 